### PR TITLE
Properly URL escape json payload in URL param during remote login

### DIFF
--- a/modules/remote.php
+++ b/modules/remote.php
@@ -152,7 +152,7 @@ class RemoteModule extends PlModule
         $response = json_encode($response);
         $location = Env::s('location');
         header('Location: ' . $site . '?location=' . $location . '&timestamp=' . $timestamp
-           . '&response='  . $response
+           . '&response='  . urlencode($response)
            . '&hash='      . md5($timestamp . $remote->privkey() . $response));
     }
 


### PR DESCRIPTION
In case the response contains special parameters like `&`.

Should fix https://panix.binets.fr/T339